### PR TITLE
Fix data relation

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -45,7 +45,7 @@ class Client
                 $data->kvkNummer ?? '',
                 $data->vestigingsnummer ?? null,
                 $data->naam ?? null,
-                $data->adres ?? null,
+                $data->adressen ?? null,
                 $data->websites ?? null
             );
         };


### PR DESCRIPTION
This pull request updates the `search` function in `src/Client.php` to replace the `adres` field with `adressen` when mapping data. 

Key change:

* [`src/Client.php`](diffhunk://#diff-40d7473316ef0bb3ba4c4d937b16ae3d1cc47e0d65815034ee2b5be6a74cb11eL48-R48): Updated the `$data` mapping to use the `adressen` field instead of `adres`, reflecting a likely change in the data structure or API response.